### PR TITLE
Remove non-awesome and outdated links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@
 
 - [Source{d}](https://go.sourced.tech/hacktoberfest)
 - [Sendgrid](https://sendgrid.com/blog/hacktoberfest-2018-hack-on-sendgrid-open-source-projects/)
-- [Microsoft](https://open.microsoft.com/2018/09/18/hacktoberfest-2018-microsoft/)
 
 ## Projects made for Hacktoberfest
 
@@ -18,16 +17,12 @@ Below you will find awesome projects that have been created specifically for Hac
 
 ### JavaScript
 
-- [hacktoberfest-checker](https://github.com/jenkoian/hacktoberfest-checker)
-- [DuhMyIP](https://github.com/thedmeyer/DuhMyIP)
 - [jest-extended](https://github.com/mattphillips/jest-extended)
 - [vue-dropzone](https://github.com/rowanwins/vue-dropzone)
 
 ### HTML
 
-- [color-hacktober](https://github.com/PAPERPANKS/color-hacktober)
 - [league_app](https://github.com/connorphee/league_app)
-- [DuhMyIP](https://github.com/thedmeyer/DuhMyIP)
 
 ### CSS
 


### PR DESCRIPTION
This is an opinionated PR.

It removes a SPAM repository: https://github.com/PAPERPANKS/color-hacktober. This is not awesome, but just for collecting PRs. See https://hacktoberfest.digitalocean.com/details#spam for details.

I removed Microsoft, because it does not participate 2019.

I removed https://github.com/jenkoian/hacktoberfest-checker, because it was double listed.

I removed DuhMyIP, because it was double listed and is not awesome (is it?)