### PR TITLE
Added Hacktoberfest Finder as a search engine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Here, you find possibilities to ease the search.
 
 - [Issue Finder](http://hacktoberfest-finder.netlify.com) - finds issues made especially for hacktoberfest, also allows filtering by language
 - [Up For Grabs](https://up-for-grabs.net/#/) - find beginner-friendly projects and issues
+- [Hacktoberfest Finder](https://hacktoberfest-finder.netlify.app/) - easy way to find issues to work on during hacktoberfest, including the ability to filter by language and least comments.
 
 ### Using labels
 

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,8 @@ Here, you find possibilities to ease the search.
 ### Search engines
 
 - [Issue Finder](http://hacktoberfest-finder.netlify.com) - finds issues made especially for hacktoberfest, also allows filtering by language
-- [Up For Grabs](https://up-for-grabs.net/#/) - find beginner-friendly projects and issues
 - [Hacktoberfest Finder](https://hacktoberfest-finder.netlify.app/) - easy way to find issues to work on during hacktoberfest, including the ability to filter by language and least comments.
+- [Up For Grabs](https://up-for-grabs.net/#/) - find beginner-friendly projects and issues
 
 ### Using labels
 


### PR DESCRIPTION
This PR adds [Hacktoberfest Finder](https://hacktoberfest-finder.netlify.app/), a small web app I've been working on the past few years with various open-source contributors that helps developers find issues to work on during Hacktoberfest.