### PR TITLE
Fix duplicate hacktoberfest link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Here, you find possibilities to ease the search.
 
 ### Search engines
 
-- [Issue Finder](http://hacktoberfest-finder.netlify.com) - finds issues made especially for hacktoberfest, also allows filtering by language
 - [Hacktoberfest Finder](https://hacktoberfest-finder.netlify.app/) - easy way to find issues to work on during hacktoberfest, including the ability to filter by language and least comments.
 - [Up For Grabs](https://up-for-grabs.net/#/) - find beginner-friendly projects and issues
 


### PR DESCRIPTION
The two different links point to the exact same website. I've removed the less detailed entry.