### PR TITLE
Add assign-issue workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,20 @@
+name: Assign Issue
+
+on:
+  schedule:
+    - cron: 3 7 * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  assign:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: takanome-dev/assign-issue-action@beta
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          maintainers: 'mattjegan,koppor'


### PR DESCRIPTION
Some contributors want to issue `/assign-me` commands to get themselves assigned. This is enabled by https://github.com/takanome-dev/assign-issue-action/.

Moreover, it unassigns after 7 days.

Could be helpful for next hacktoberfest